### PR TITLE
Update Node.js version to 8.11.3 from 8.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/actcat/devon_rex_base:1.0.8
 
-ENV NODE_VERSION=8.5.0
+ENV NODE_VERSION=8.11.3
 RUN curl -sSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz \
     | tar -C /usr/local -x --xz --strip 1


### PR DESCRIPTION
See https://3.basecamp.com/3787557/buckets/4315169/todos/1165261784
I updated Node.js version to 8.11.3 that is the latest version on 9th July.

Most of the changes include dealing with CVE, HTTP/2, OpenSSL, and updating NPM and other libraries. The details are:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md